### PR TITLE
fix:aerich migrate raise err: tortoise.exceptions.ConfigurationError:…

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -173,6 +173,7 @@ class Migrate:
         temp_config = deepcopy(config)
         path = os.path.join(location, app, cls.old_models)
         path = path.replace("/", ".").lstrip(".")
+        path = path.replace("\\", ".")
         temp_config["apps"][cls.diff_app] = {
             "models": [path],
             "default_connection": config.get("apps").get(app).get("default_connection", "default"),


### PR DESCRIPTION
… Module "migrations\models\old_models" not found
我使用migrate命令的时候，报错，调试后发现，您组的迁移配置路劲如下
diff_models：{“models” : ["migrates\\models\\old_models"]}
tortoise-orm不能识别，只支持 "migrates.models.old_models"
所以我做了如下更改