### PR TITLE
Allow longer migration version names

### DIFF
--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -17,7 +17,7 @@ from tortoise import (
 from tortoise.fields import Field
 
 from aerich.ddl import BaseDDL
-from aerich.models import Aerich
+from aerich.models import Aerich, MAX_VERSION_LENGTH
 from aerich.utils import get_app_connection
 
 
@@ -89,7 +89,10 @@ class Migrate:
         last_version_num = await cls._get_last_version_num()
         if last_version_num is None:
             return f"0_{now}_init.json"
-        return f"{last_version_num + 1}_{now}_{name}.json"
+        version = f"{last_version_num + 1}_{now}_{name}.json"
+        if len(version) > MAX_VERSION_LENGTH:
+            raise ValueError(f"Version name exceeds maximum length ({MAX_VERSION_LENGTH})")
+        return version
 
     @classmethod
     async def _generate_diff_sql(cls, name):

--- a/aerich/migrate.py
+++ b/aerich/migrate.py
@@ -17,7 +17,7 @@ from tortoise import (
 from tortoise.fields import Field
 
 from aerich.ddl import BaseDDL
-from aerich.models import Aerich, MAX_VERSION_LENGTH
+from aerich.models import MAX_VERSION_LENGTH, Aerich
 from aerich.utils import get_app_connection
 
 

--- a/aerich/models.py
+++ b/aerich/models.py
@@ -1,8 +1,10 @@
 from tortoise import Model, fields
 
+MAX_VERSION_LENGTH = 255
+
 
 class Aerich(Model):
-    version = fields.CharField(max_length=50)
+    version = fields.CharField(max_length=MAX_VERSION_LENGTH)
     app = fields.CharField(max_length=20)
 
     class Meta:


### PR DESCRIPTION
The 50 character limit on the `version` column in the aerich database forces very short version names. This PR would increase the limit to 255 to allow for longer version names. If this change seems ok and you would not be opposed to exceeding the limit for a `CHAR` field in MySQL, I would personally favour increasing the limit even further.

Also included in the PR is a change to when the user encounters an error for a too-lengthy version name. When I ran into the error while running the `upgrade` command, it was not immediately obvious to me that I was having a problem with the aerich database (as opposed to the contents of my migrations). To me it would be clearer to have the error raised at the time the migration is generated.

Thanks for your work to provide a migrations tool for Tortoise!