### PR TITLE
Close database connections

### DIFF
--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import os
 import sys
@@ -25,6 +26,16 @@ class Color(str, Enum):
 
 
 parser = ConfigParser()
+
+
+def close_db(func):
+    @functools.wraps(func)
+    async def close_db_inner(*args, **kwargs):
+        result = await func(*args, **kwargs)
+        await Tortoise.close_connections()
+        return result
+
+    return close_db_inner
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -162,7 +162,7 @@ async def heads(ctx: Context):
 @cli.command(help="List all migrate items.")
 @click.pass_context
 @close_db
-async def history(ctx):
+async def history(ctx: Context):
     versions = Migrate.get_all_version_files()
     for version in versions:
         click.secho(version, fg=Color.green)

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -81,6 +81,7 @@ async def cli(ctx: Context, config, app, name):
 @cli.command(help="Generate migrate changes file.")
 @click.option("--name", default="update", show_default=True, help="Migrate name.")
 @click.pass_context
+@close_db
 async def migrate(ctx: Context, name):
     config = ctx.obj["config"]
     location = ctx.obj["location"]
@@ -95,6 +96,7 @@ async def migrate(ctx: Context, name):
 
 @cli.command(help="Upgrade to latest version.")
 @click.pass_context
+@close_db
 async def upgrade(ctx: Context):
     config = ctx.obj["config"]
     app = ctx.obj["app"]
@@ -121,6 +123,7 @@ async def upgrade(ctx: Context):
 
 @cli.command(help="Downgrade to previous version.")
 @click.pass_context
+@close_db
 async def downgrade(ctx: Context):
     app = ctx.obj["app"]
     config = ctx.obj["config"]
@@ -143,6 +146,7 @@ async def downgrade(ctx: Context):
 
 @cli.command(help="Show current available heads in migrate location.")
 @click.pass_context
+@close_db
 async def heads(ctx: Context):
     app = ctx.obj["app"]
     versions = Migrate.get_all_version_files()
@@ -207,6 +211,7 @@ async def init(
     show_default=True,
 )
 @click.pass_context
+@close_db
 async def init_db(ctx: Context, safe):
     config = ctx.obj["config"]
     location = ctx.obj["location"]

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -161,7 +161,7 @@ async def heads(ctx: Context):
 
 @cli.command(help="List all migrate items.")
 @click.pass_context
-def history(ctx):
+async def history(ctx):
     versions = Migrate.get_all_version_files()
     for version in versions:
         click.secho(version, fg=Color.green)

--- a/aerich/cli.py
+++ b/aerich/cli.py
@@ -161,6 +161,7 @@ async def heads(ctx: Context):
 
 @cli.command(help="List all migrate items.")
 @click.pass_context
+@close_db
 async def history(ctx):
     versions = Migrate.get_all_version_files()
     for version in versions:


### PR DESCRIPTION
aerich does not explicitly close the opened database connections, which leads to some strange behaviour when using sqlite:

- The thread opened under the hood by the async sqlite library never finishes, so after the aerich is done the user has to end the process manually or it hangs forever
- Temp sqlite db files are created but never cleaned up

This PR introduces a decorator that will call the `Tortoise.close_connections` helper after a function is run, and attaches that decorator to the click command functions that open a db connection. I elected to use a decorator here because some of the command functions return early under some conditions, and this way I didn't have to handle every special case separately.

Unlike the rest of the click command functions, the `history` function was synchronous (not async). This PR changes it to be an async function so it is compatible with the `close_db` decorator. Let me know if `history` was kept synchronous on purpose and this change would break something.